### PR TITLE
Code cleanup, promises and packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
+.babelrc
+.gitignore
+.npmignore
+.travis.yml
 src
+test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --compilers js:babel-core/register -R spec src/test/*.js src/modules/**/test/*.js",
-    "compile": "rm -r lib/; babel src --out-dir lib --ignore src/test",
+    "compile": "rm -rf lib/; babel src --out-dir lib --ignore src/test",
     "prepublish": "npm run compile",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/*.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",
     "publish-docs": "npm run build-docs && git add ./README.md && git commit -m 'Updated README API Docs' && git push"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --compilers js:babel-core/register -R spec src/test/*.js src/modules/**/test/*.js",
-    "compile": "babel src --out-dir lib",
+    "compile": "rm -r lib/; babel src --out-dir lib --ignore src/test",
     "prepublish": "npm run compile",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/*.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",
     "publish-docs": "npm run build-docs && git add ./README.md && git commit -m 'Updated README API Docs' && git push"

--- a/src/modules/templater-ejs/index.js
+++ b/src/modules/templater-ejs/index.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird'
 import uuid from 'uuid'
 
 import {NxusModule} from 'nxus-core'
@@ -35,7 +36,7 @@ class TemplaterEjs extends NxusModule {
     }
     return [type, content, opts]
   }
-  
+
   _localsAfter(result, [type, content, opts]) {
     if (opts._renderedPartials && _.isString(result)) {
       return Promise.mapSeries(Object.keys(opts._renderedPartials), (id) => {


### PR DESCRIPTION
I think these changes are all totally routine. However, I added a bunch of excludes to .npmignore, so you might take a look at what ends up in the npm package (package.json, README.md, lib/*.js, and lib/modules). I think everything else was superfluous.

My plan, if I don't hear any objections in the next couple days, is to merge these changes, and also bump the version to 4.0.0.

More details:

In package.json, changed compile script to first do a `rm -r lib`, to clear out any obsoleted files; added `--ignore src/test` to babel, so test files aren't compiled.

In templater-ejs/index.js, imported bluebird (needed for `Promise.map()`).