### PR TITLE
Fixed corruption of results from render() helper function.

### DIFF
--- a/src/modules/templater-ejs/index.js
+++ b/src/modules/templater-ejs/index.js
@@ -44,7 +44,8 @@ class TemplaterEjs extends NxusModule {
         // TODO this probably is never used
         if(opts._inlineRenderId == id) return Promise.resolve(result)
         return opts._renderedPartials[id].then((part) => {
-          result = result.replace('<<<'+id+'>>>', part)
+          result = result.replace('<<<'+id+'>>>', () => part)
+              // use a replacement function to suppress pattern processing in replacement string
           delete opts._renderedPartials[id]
           return result
         })


### PR DESCRIPTION
The `render()` helper function uses the string `replace()` method to insert its rendered results in the output string. Unfortunately, the `replace()` method checks for replacement patterns in the replacement string, and modifies the string if any are present. So, if the rendered results happen to contain content that looks like a replacement pattern, bad things happen.

Tweaked the `.replace()` invocation to deliver the replacement string with a function, which suppresses replacement pattern processing.